### PR TITLE
Update repo badges after org name change [no-ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
 # Flood risk acceptance tests
 
-[![Build Status](https://travis-ci.org/EnvironmentAgency/flood-risk-acceptance-tests.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/flood-risk-acceptance-tests)
-[![security](https://hakiri.io/github/EnvironmentAgency/flood-risk-acceptance-tests/master.svg)](https://hakiri.io/github/EnvironmentAgency/flood-risk-acceptance-tests/master)
-[![Code Climate](https://codeclimate.com/github/EnvironmentAgency/flood-risk-acceptance-tests/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/flood-risk-acceptance-tests)
-[![Dependency Status](https://dependencyci.com/github/EnvironmentAgency/flood-risk-acceptance-tests/badge)](https://dependencyci.com/github/EnvironmentAgency/flood-risk-acceptance-tests)
+[![Build Status](https://travis-ci.org/DEFRA/flood-risk-acceptance-tests.svg?branch=master)](https://travis-ci.org/DEFRA/flood-risk-acceptance-tests)
+[![security](https://hakiri.io/github/DEFRA/flood-risk-acceptance-tests/master.svg)](https://hakiri.io/github/DEFRA/flood-risk-acceptance-tests/master)
+[![Dependency Status](https://dependencyci.com/github/DEFRA/flood-risk-acceptance-tests/badge)](https://dependencyci.com/github/DEFRA/flood-risk-acceptance-tests)
 
 You may need an environmental permit if you want to work in, over, under or near a main river or flood or sea defence. Some flood risk activities are exempt from needing a permit and you can carry out the work if you [register an exemption](https://www.gov.uk/guidance/register-your-flood-risk-exemption-environmental-permits).
 
 [Register a flood risk activity exemption](https://register-flood-risk-exemption.service.gov.uk/) is the digital service which allows users to register an exemption.
 
-This project contains the acceptance tests for the service. It is built around [Quke](https://github.com/EnvironmentAgency/quke), a Ruby gem that simplifies the process of writing and running Cucumber acceptance tests.
+This project contains the acceptance tests for the service. It is built around [Quke](https://github.com/DEFRA/quke), a Ruby gem that simplifies the process of writing and running Cucumber acceptance tests.
 
 ## Pre-requisites
 
 This project is setup to run against version 2.3.1 of Ruby.
 
-The rest of the pre-requisites are the same as those for [Quke](https://github.com/EnvironmentAgency/quke#pre-requisites).
+The rest of the pre-requisites are the same as those for [Quke](https://github.com/DEFRA/quke#pre-requisites).
 
 ## Installation
 
 First clone the repository and then drop into your new local repo
 
 ```bash
-git clone https://github.com/EnvironmentAgency/flood-risk-acceptance-tests.git && cd flood-risk-acceptance-tests
+git clone https://github.com/DEFRA/flood-risk-acceptance-tests.git && cd flood-risk-acceptance-tests
 ```
 
 Next download and install the dependencies
@@ -33,7 +32,7 @@ bundle install
 
 ## Configuration
 
-You can figure how the project runs using [Quke config files](https://github.com/EnvironmentAgency/quke#configuration). Before executing this project for the first time you'll need to create an initial `.config.yml` file.
+You can figure how the project runs using [Quke config files](https://github.com/DEFRA/quke#configuration). Before executing this project for the first time you'll need to create an initial `.config.yml` file.
 
 ```bash
 touch .config.yml
@@ -63,7 +62,7 @@ Simply call
 bundle exec quke
 ```
 
-You can create [multiple config files](https://github.com/EnvironmentAgency/quke#multiple-configs), for example you may wish to have one setup for running against **Chrome**, and another to run against a different environment. You can tell **Quke** which config file to use by adding an environment variable argument to the command.
+You can create [multiple config files](https://github.com/DEFRA/quke#multiple-configs), for example you may wish to have one setup for running against **Chrome**, and another to run against a different environment. You can tell **Quke** which config file to use by adding an environment variable argument to the command.
 
 ```bash
 QUKE_CONFIG='chrome.config.yml' bundle exec quke


### PR DESCRIPTION
The Environment Agency organisation on GitHub recently changed its name to DEFRA. This has resulted in a change to all the urls for all our repos. This change fixes the badges and updates any links using the old name.