### PR TITLE
Add scenario 2 reproduce duplicate regs in search

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,13 @@ Style/EmptyLinesAroundBlockBody:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+# Steps aren't like traditional methods and don't benefit from being broken
+# down. Therefore we exclude them from the block length metric as they often can
+# be long.
+Metrics/BlockLength:
+  Exclude:
+    - "**/features/step_definitions/**/*_steps.rb"
+
 # We believe the default of 10 lines for a method length is too restrictive and
 # often quickly hit just because we need to specify the namesspace, class and
 # method before then doing something with it.

--- a/features/back_office_registration.feature
+++ b/features/back_office_registration.feature
@@ -12,3 +12,19 @@ Feature: NCCC user administers a flood risk activity exemptions on behalf of a c
   Scenario: Registration of a flood risk activity exemption by NCCC staff using the backoffice system
      When I register a flood risk activity exemption for a customer
      Then I will see confirmation the registration has been submitted
+
+  # Multiple organisation addresses against applications
+  #
+  # Initially reported by NCCC that there were duplicate exemption records in
+  # the system. We found that there is no duplication of application or
+  # enrolment records, but the records that appear twice do so because they have
+  # multiple addresses listed as their ‘organisation’ address.
+  #
+  # This scenario covers the steps necessary to reproduce the problem. See
+  # https://eaflood.atlassian.net/browse/RIP-359 for more details.
+  @fix
+  Scenario: Registration in the backoffice where the user goes back and re-enters the address manually
+    Given I get to the check your answers page
+     And The user wishes to correct their address
+     When I enter the address manually and complete the registration
+     Then I should see just one result when searching for the registration

--- a/features/page_objects/address_page.rb
+++ b/features/page_objects/address_page.rb
@@ -3,6 +3,8 @@ class AddressPage < SitePrism::Page
   element(:show_list, "input#address_match_selection")
   element(:results_dropdown, "select#address_match_selection")
 
+  element(:cannot_find_address_link, "fieldset+ p .change-postcode-button")
+
   element(:address_premises, "input#address_premises")
   element(:street_address, "input#address_street_address")
   element(:address_locality, "input#address_locality")
@@ -15,8 +17,8 @@ class AddressPage < SitePrism::Page
 
     address_premises.set(args[:address_premises]) if args.key?(:address_premises)
     street_address.set(args[:street_address]) if args.key?(:street_address)
-    telephone_number.set(args[:address_locality]) if args.key?(:address_locality)
-    telephone_number.set(args[:address_city]) if args.key?(:address_city)
+    address_locality.set(args[:address_locality]) if args.key?(:address_locality)
+    address_city.set(args[:address_city]) if args.key?(:address_city)
 
     submit_button.click
   end

--- a/features/page_objects/check_your_answers_page.rb
+++ b/features/page_objects/check_your_answers_page.rb
@@ -1,5 +1,7 @@
 class CheckYourAnswersPage < SitePrism::Page
 
+  element(:back_link, ".back-link")
+
   element(:submit_button, "input[name='commit']")
 
 end

--- a/features/page_objects/correspondence_contact_email.rb
+++ b/features/page_objects/correspondence_contact_email.rb
@@ -1,5 +1,7 @@
 class CorrespondenceContactEmailPage < SitePrism::Page
 
+  element(:back_link, ".back-link")
+
   element(:email, "input#correspondence_contact_email_email_address")
   element(:confirm_email, "input#correspondence_contact_email_email_address_confirmation")
 

--- a/features/page_objects/correspondence_contact_name_page.rb
+++ b/features/page_objects/correspondence_contact_name_page.rb
@@ -1,5 +1,7 @@
 class CorrespondenceContactNamePage < SitePrism::Page
 
+  element(:back_link, ".back-link")
+
   element(:full_name, "input[name='correspondence_contact_name[full_name]']")
   element(:position, "input[name='correspondence_contact_name[position]']")
 

--- a/features/page_objects/correspondence_contact_telephone_page.rb
+++ b/features/page_objects/correspondence_contact_telephone_page.rb
@@ -1,5 +1,7 @@
 class CorrespondenceContactTelephonePage < SitePrism::Page
 
+  element(:back_link, ".back-link")
+
   element(
     :telephone_number,
     "input[name='correspondence_contact_telephone[telephone_number]']"

--- a/features/page_objects/email_someone_else_page.rb
+++ b/features/page_objects/email_someone_else_page.rb
@@ -1,5 +1,7 @@
 class EmailSomeoneElsePage < SitePrism::Page
 
+  element(:back_link, ".back-link")
+
   element(:email, "input#email_someone_else_email_address")
   element(:confirm_email, "input#email_someone_else_email_address_confirmation")
 

--- a/features/page_objects/search_page.rb
+++ b/features/page_objects/search_page.rb
@@ -11,6 +11,8 @@ class SearchPage < SitePrism::Page
 
   element(:registration_status, "tr:nth-child(1) .label-danger")
 
+  elements(:search_results_view_btns, ".btn-primary")
+
   section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
 
 end

--- a/features/step_definitions/back_office/admin_login_steps.rb
+++ b/features/step_definitions/back_office/admin_login_steps.rb
@@ -6,6 +6,11 @@ Given(/^I have a valid username and password$/) do
     password: "Abcde12345"
   )
 
+  # If we don't check for some form of confirmation that we have logged in,
+  # though the scenario will fail it will report the proceeding step as the
+  # culprit, rather than the login
+  expect(@app.search_page).to have_alert_success
+
 end
 
 Given(/^I have an invalid username and password$/) do
@@ -15,6 +20,8 @@ Given(/^I have an invalid username and password$/) do
     email: "mister.tumble@example.co.uk",
     password: "Abcde12345"
   )
+
+  expect(@app.login_page).to have_alert_invalid
 
 end
 

--- a/features/step_definitions/back_office/correct_address_steps.rb
+++ b/features/step_definitions/back_office/correct_address_steps.rb
@@ -1,0 +1,104 @@
+Given(/^I get to the check your answers page$/) do
+  @app.search_page.nav_bar.registrations_menu.click
+  @app.search_page.nav_bar.new_option.click
+
+  @app.add_exemption_page.submit(
+    exemption: "FRA2"
+  )
+
+  expect(page).to have_content("FRA2")
+  @app.check_exemptions_page.submit_button.click
+
+  @app.grid_reference_page.submit(
+    grid_reference: "ST 58132 72695",
+    description: "Location of activity"
+  )
+
+  # User type page
+  @app.user_type_page.submit(org_type: "individual")
+
+  # Organisation name page
+  @app.organisation_name_page.submit(individual_name: "Tina Turner")
+
+  # Postcode page
+  @app.postcode_page.submit(individual_postcode: "BS1 5AH")
+
+  # Address page - select address from post code lookup list
+  @app.address_page.submit(
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+  )
+
+  # Correspondence contact name page
+  @app.correspondence_contact_name_page.submit(
+    full_name: "Joe Bloggs",
+    position: "Project Manager"
+  )
+
+  # Correspondence contact telephone page
+  @app.correspondence_contact_telephone_page.submit(
+    telephone_number: "01234567899"
+  )
+
+  # Correspondence contact email address page
+  @app.correspondence_contact_email_page.submit(
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
+  )
+
+  # Email someone else page
+  @app.email_someone_else_page.submit(
+    email: "tim.stone.ea+1@gmail.com",
+    confirm_email: "tim.stone.ea+1@gmail.com"
+  )
+
+  expect(@app.check_your_answers_page.current_url).to end_with "/steps/check_your_answers"
+end
+
+And(/^The user wishes to correct their address$/) do
+
+  @app.check_your_answers_page.back_link.click
+  @app.email_someone_else_page.back_link.click
+  @app.correspondence_contact_email_page.back_link.click
+  @app.correspondence_contact_telephone_page.back_link.click
+  @app.correspondence_contact_name_page.back_link.click
+
+  expect(@app.address_page.current_url).to end_with "_address"
+
+end
+
+When(/^I enter the address manually and complete the registration$/) do
+
+  @app.address_page.cannot_find_address_link.click
+
+  # Address page - enter manual details
+  @app.address_page.submit(
+    address_premises: "environment agency",
+    street_address: "horizon house",
+    address_locality: "deanery road",
+    address_city: "bristol"
+  )
+
+  @app.correspondence_contact_name_page.submit_button.click
+  @app.correspondence_contact_telephone_page.submit_button.click
+  @app.correspondence_contact_email_page.submit_button.click
+  @app.email_someone_else_page.submit_button.click
+  @app.check_your_answers_page.submit_button.click
+
+  @app.declaration_page.declaration_button.click
+
+  @exemption_number = @app.confirmation_page.exemption_number.text
+
+  expect(@exemption_number).to start_with "EXFRA"
+
+end
+
+Then(/^I should see just one result when searching for the registration$/) do
+
+  # search page
+  @app.search_page.nav_bar.home_link.click
+  @app.search_page.search_field.set @exemption_number
+  @app.search_page.search_button.click
+
+  expect(@app.search_page.search_results_view_btns.size).to eq(1)
+
+end

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 When(/^I register a flood risk activity exemption for a customer$/) do
 
   @app.search_page.nav_bar.registrations_menu.click
@@ -61,7 +60,6 @@ When(/^I register a flood risk activity exemption for a customer$/) do
   @exemption_number = @app.confirmation_page.exemption_number.text
 
 end
-# rubocop:enable Metrics/BlockLength
 
 Then(/^I will see confirmation the registration has been submitted$/) do
 

--- a/features/step_definitions/front_office/partnership_steps.rb
+++ b/features/step_definitions/front_office/partnership_steps.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 Given(/^I am a partnership$/) do
   # User type page
   @app.user_type_page.submit(org_type: "partnership")
@@ -62,7 +61,6 @@ Given(/^I am a partnership$/) do
   # Check your answers page
   @app.check_your_answers_page.submit_button.click
 end
-# rubocop:enable Metrics/BlockLength
 
 And(/^add "([^"]*)" as the first partner$/) do |name|
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-359

This change adds a scenario which reproduces a situation where an exemption will appear twice in the back office search results because it has multiple organisation address listed as the primary.

There should only ever be one address linked to the record as the primary address, however by using the back links and choosing to re-enter the address manually we can demonstrate how 2 address records are created, linked to the organisation record (which in turn is linked to the enrollment record) resulting in the exemption appearing twice in search results.