### PR TITLE
Update tag details 2b consistent with other projs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To have consistency across the project the following tags are defined and should
 |@backoffice|Any feature or scenario expected to be run against the back office application|
 |@happypath|A scenario which details a complete registration with no errors|
 |@functional|Any feature or scenario which is testing just a specific function of the service e.g. validation errors|
+|@fix|A feature or scenario that highlights an error or issue with the service that needs to be fixed|
 |@ci|A feature that is intended to be run only on our continuous integration service (you should never need to use this tag).|
 
 It's also common practice to use a custom tag whilst working on a new feature or scenario e.g. `@focus` or `@wip`. That is perfectly acceptable but please ensure they are removed before your change is merged.


### PR DESCRIPTION
This simply updates the table in the README that contains details of the tags that should be assigned to features and scenarios, to bring them inline with other acceptance test projects.