### PR TITLE
Lock Capybara to version 2.14.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,12 @@ gem "rubocop", require: false
 # Hence by referring to it here we can lock the version to one we know allows
 # this project to run in our environments.
 gem "chromedriver-helper", "1.0.0"
+
+# We don't actually need a reference to capybara for this project; quke itself
+# brings it in. However when the gem updated to 2.14.1 it appears to have broken
+# our ability to confirm the javascript prompt that is shown when deleting a
+# partner.
+# https://github.com/teamcapybara/capybara/blob/master/History.md#version-2141
+# So until we understand what the problem is and how to resolve it we need to
+# lock the project to a version we know works.
+gem "capybara", "2.14.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,13 @@ GEM
     ast (2.3.0)
     browserstack-local (1.3.0)
     builder (3.2.3)
-    capybara (2.17.0)
+    capybara (2.14.0)
       addressable
-      mini_mime (>= 0.1.3)
+      mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      xpath (~> 2.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.0.0)
@@ -38,7 +38,9 @@ GEM
     io-like (0.3.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    mini_mime (1.0.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -93,13 +95,14 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.0.0)
-      nokogiri (~> 1.8)
+    xpath (2.1.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara (= 2.14.0)
   chromedriver-helper (= 1.0.0)
   quke
   rake


### PR DESCRIPTION
In recent testing we have found that the scenario 'Add 3 partners then remove one' in `partnership.feature is failing because it is unable to confirm the javascript prompt that is displayed. When run on the line `page.accept_confirm` when called we get a `undefined method `[]' for nil:NilClass (NoMethodError)`.

The release notes for 2.14.1 list _Workaround broken system modals when using selenium with headless Chrome_ so it may be that this fix is actually a breaking change for us.

Therefore reverting the version back until we understand how to fix it.