### PR TITLE
Fix broken postcode lookup after OS places change

### DIFF
--- a/features/step_definitions/back_office/correct_address_steps.rb
+++ b/features/step_definitions/back_office/correct_address_steps.rb
@@ -25,7 +25,7 @@ Given(/^I get to the check your answers page$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -26,7 +26,7 @@ When(/^I register a flood risk activity exemption for a customer$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page

--- a/features/step_definitions/front_office/check_your_answers_steps.rb
+++ b/features/step_definitions/front_office/check_your_answers_steps.rb
@@ -8,7 +8,7 @@ And(/^complete the remaining steps as an individual$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page

--- a/features/step_definitions/front_office/individual_steps.rb
+++ b/features/step_definitions/front_office/individual_steps.rb
@@ -10,7 +10,7 @@ Given(/^I am an individual$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page

--- a/features/step_definitions/front_office/llp_partnership_steps.rb
+++ b/features/step_definitions/front_office/llp_partnership_steps.rb
@@ -13,7 +13,7 @@ Given(/^I am a limited liability partnership$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page

--- a/features/step_definitions/front_office/local_authority_steps.rb
+++ b/features/step_definitions/front_office/local_authority_steps.rb
@@ -10,7 +10,7 @@ Given(/^I am a local authority$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page

--- a/features/step_definitions/front_office/ltd_company_steps.rb
+++ b/features/step_definitions/front_office/ltd_company_steps.rb
@@ -13,7 +13,7 @@ Given(/^I am a limited company$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page

--- a/features/step_definitions/front_office/other_registration_steps.rb
+++ b/features/step_definitions/front_office/other_registration_steps.rb
@@ -10,7 +10,7 @@ Given(/^I am a charity$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page

--- a/features/step_definitions/front_office/partnership_steps.rb
+++ b/features/step_definitions/front_office/partnership_steps.rb
@@ -10,7 +10,7 @@ Given(/^I am a partnership$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Partnership details page
@@ -28,7 +28,7 @@ Given(/^I am a partnership$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Partnership details page - again!
@@ -72,7 +72,7 @@ And(/^add "([^"]*)" as the first partner$/) do |name|
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
 end
@@ -92,7 +92,7 @@ And(/^add "([^"]*)" as a partner$/) do |name|
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
 end
@@ -112,7 +112,7 @@ And(/^add "([^"]*)" as the last partner$/) do |name|
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Partnership details page
@@ -129,7 +129,7 @@ But(/^then remove "([^"]*)" from the partners list$/) do |name|
   # passing the code which causes the dialog to appear as a block to the method.
   # http://www.rubydoc.info/github/jnicklas/capybara/Capybara%2FSession%3Aaccept_confirm
   # http://stackoverflow.com/a/26348968/6117745
-  page.accept_confirm do
+  page.accept_alert do
     @app.partnership_details_page.remove_link(name).click
   end
 


### PR DESCRIPTION
A change appears to have happened for the EA address entry using OS Places. Now when searching for **BS1 5AH** the environment agency is no longer returned in the results. Instead we get *NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH*.

This change updates anywhere we were previously expecting the old address entry to look for the new one.