### PR TITLE
Add ability to specifiy custom screen size

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Into that file you'll need to add the `app_host:` entry, with the url of the FRA
 
 If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**.
 
+### Custom FRAE config
+
+Recently we have needed to add special logic for running the tests in our environments (dev, QA and Pre-prod). Though fine locally tests are failing if the a submit button is 'off the page' i.e. you would need to scroll to click it. Because of this when setting up the tests to run automatically from the Jenkins slave you will need to add the following to the `.config.yml`.
+
+```yaml
+custom:
+  window_size:
+    width: 1000
+    height: 2000
+```
+
+The project now includes logic to look for this and if present will resize the window accordingly. Ideally this situation should be periodically tested to see if this workaround is still required.
+
 ### Back office
 
 The project contains logic to automatically determine the URL to the back office, by assuming `app_host:` is the front office URL for one of our standard environments (development, QA, pre-prod or production).

--- a/features/hooks/before.rb
+++ b/features/hooks/before.rb
@@ -1,0 +1,18 @@
+Before do
+  # As of 2018-01-15 it appears that tests do not complete in our environments
+  # if an element is not visible on the page. This should not be a problem and
+  # cannot be replicated locally, however has been confirmed in our pre-prod
+  # environment. The error we get is
+  # Element is not clickable at point (89, 2611)
+  # The element in question is the continue (submit) button which on certain
+  # pages using the default screen size is out of view.
+  # Therefore we've added this functionality that looks for a custom
+  # window_size element on the config object and if present, sets the window
+  # size at the start of each test
+  if Quke::Quke.config.custom && Quke::Quke.config.custom["window_size"]
+    Capybara.current_session.current_window.resize_to(
+      Quke::Quke.config.custom["window_size"]["width"],
+      Quke::Quke.config.custom["window_size"]["height"]
+    )
+  end
+end


### PR DESCRIPTION
As of writing it was 10 months since the tests ran successfully in our environments. When attempting to confirm the service after some emergency patching of the environments we

- could not get the acceptance tests to connect to chrome (20a8ea7)
- errored when trying to confirm the JavaScript prompt after deleting a partner (35920c1)
- could not select the correct address (ac95bb8)

With those issues out of the way, and the versions fixed we then found we were experiencing the [same problem as the WEX acceptance test project](https://github.com/DEFRA/waste-exemptions-acceptance-tests/pull/59). Basically in our Jenkins CI environment if an element is not visible in the display port Capybara cannot select it.

So we have implmented the same fix, which is to add the ability to specify a custom screen size within the config.