### PR TITLE
Change hard coded email addresses

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -9,7 +9,9 @@
 # will be by simply setting `app_host`. You can then use it directly using
 # Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
 # the full url each time
-app_host: 'https://fra-pre.aws.defra.cloud'
+# app_host: 'http://localhost:3000'
+app_host: 'https://fra-tst.aws.defra.cloud'
+# app_host: 'https://fra-pre.aws.defra.cloud'
 
 # Tells Quke which browser to use for testing. Choices are firefox, chrome
 # browserstack and phantomjs, with the default being phantomjs
@@ -34,9 +36,17 @@ max_wait_time: 5
 custom:
   accounts:
     SystemUser:
-      username: tim.stone.ea@gmail.com
+      username: applicant1@example.com
+      username2: applicant2@example.com
       password: Abcde12345
 
   urls:
-    front_office: "https://fra-pre.aws.defra.cloud"
-    back_office: "https://fra-admin-pre.aws.defra.cloud"
+    # local
+    # front_office: "http://localhost:3000"
+    # back_office: "http://localhost:8000"
+    # test
+    front_office: "https://fra-tst.aws.defra.cloud"
+    back_office: "https://fra-admin-tst.aws.defra.cloud"
+    # preprod
+    # front_office: "https://fra-pre.aws.defra.cloud"
+    # back_office: "https://fra-admin-pre.aws.defra.cloud"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project contains the acceptance tests for the service. It is built around [
 
 ## Pre-requisites
 
-This project is setup to run against version 2.3.1 of Ruby.
+This project is setup to run against version 2.4.2 of Ruby.
 
 The rest of the pre-requisites are the same as those for [Quke](https://github.com/DEFRA/quke#pre-requisites).
 

--- a/features/step_definitions/back_office/admin_login_steps.rb
+++ b/features/step_definitions/back_office/admin_login_steps.rb
@@ -1,8 +1,10 @@
 Given(/^I have a valid username and password$/) do
   # Back office login page
   @app.login_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
-    password: Quke::Quke.config.custom["accounts"]["SystemUser"]["password"]
+    # email: email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    # password: Quke::Quke.config.custom["accounts"]["SystemUser"]["password"]
+    email: ENV["FRAE_DEFAULT_USERNAME"], # this comes from your local machine
+    password: ENV["FRAE_DEFAULT_PASSWORD"]
   )
 
   # If we don't check for some form of confirmation that we have logged in,
@@ -17,7 +19,7 @@ Given(/^I have an invalid username and password$/) do
   # Back office login page
   @app.login_page.submit(
     email: "mister.tumble@example.co.uk",
-    password: ENV["FRAE_DEFAULT_PASSWORD"]
+    password: "cheesicles" # was ENV["FRAE_DEFAULT_PASSWORD"]
   )
 
   expect(@app.login_page).to have_alert_invalid

--- a/features/step_definitions/back_office/correct_address_steps.rb
+++ b/features/step_definitions/back_office/correct_address_steps.rb
@@ -41,14 +41,14 @@ Given(/^I get to the check your answers page$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: "tim.stone.ea+1@gmail.com",
-    confirm_email: "tim.stone.ea+1@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   expect(@app.check_your_answers_page.current_url).to end_with "/steps/check_your_answers"

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -42,14 +42,14 @@ When(/^I register a flood risk activity exemption for a customer$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: "tim.stone.ea+1@gmail.com",
-    confirm_email: "tim.stone.ea+1@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/check_your_answers_steps.rb
+++ b/features/step_definitions/front_office/check_your_answers_steps.rb
@@ -24,8 +24,8 @@ And(/^complete the remaining steps as an individual$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
@@ -44,7 +44,7 @@ Then(/^I will see all the details I entered as an individual$/) do
   expect(page).to have_content "HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   expect(page).to have_content "Napoleon Solo (Owner)"
   expect(page).to have_content "01234567899"
-  expect(page).to have_content "tim.stone.ea@gmail.com"
+  # email address removed as this currently changes by environment
 
 end
 
@@ -60,6 +60,6 @@ Then(/^I will see all the details I entered as a partnership$/) do
   expect(page).to have_content "Tony Stark, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   expect(page).to have_content "Nick Fury (Project Manager)"
   expect(page).to have_content "01234567899"
-  expect(page).to have_content "tim.stone.ea@gmail.com"
+  # email address removed as this currently changes by environment
 
 end

--- a/features/step_definitions/front_office/individual_steps.rb
+++ b/features/step_definitions/front_office/individual_steps.rb
@@ -26,14 +26,14 @@ Given(/^I am an individual$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: "tim.stone.ea+1@gmail.com",
-    confirm_email: "tim.stone.ea+1@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/llp_partnership_steps.rb
+++ b/features/step_definitions/front_office/llp_partnership_steps.rb
@@ -29,14 +29,14 @@ Given(/^I am a limited liability partnership$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: "tim.stone.ea+1@gmail.com",
-    confirm_email: "tim.stone.ea+1@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/local_authority_steps.rb
+++ b/features/step_definitions/front_office/local_authority_steps.rb
@@ -26,14 +26,14 @@ Given(/^I am a local authority$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: "tim.stone.ea+1@gmail.com",
-    confirm_email: "tim.stone.ea+1@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   @app.check_your_answers_page.submit_button.click

--- a/features/step_definitions/front_office/ltd_company_steps.rb
+++ b/features/step_definitions/front_office/ltd_company_steps.rb
@@ -29,14 +29,14 @@ Given(/^I am a limited company$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: "tim.stone.ea+1@gmail.com",
-    confirm_email: "tim.stone.ea+1@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/other_registration_steps.rb
+++ b/features/step_definitions/front_office/other_registration_steps.rb
@@ -3,7 +3,7 @@ Given(/^I am a charity$/) do
   @app.user_type_page.submit(org_type: "other")
 
   # Organisation name page
-  @app.organisation_name_page.submit(other_name: "Boy scouts")
+  @app.organisation_name_page.submit(other_name: "Save The Biscuits")
 
   # Postcode page
   @app.postcode_page.submit(other_postcode: "BS1 5AH")
@@ -26,14 +26,14 @@ Given(/^I am a charity$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: "tim.stone.ea+1@gmail.com",
-    confirm_email: "tim.stone.ea+1@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/partnership_steps.rb
+++ b/features/step_definitions/front_office/partnership_steps.rb
@@ -3,7 +3,7 @@ Given(/^I am a partnership$/) do
   @app.user_type_page.submit(org_type: "partnership")
 
   # Organisation name page
-  @app.organisation_name_page.submit(partnership_full_name: "Mickey Mouse")
+  @app.organisation_name_page.submit(partnership_full_name: "Fray and Bentos Associates")
 
   # Postcode page
   @app.postcode_page.submit(partnership_postcode: "BS1 5AH")
@@ -19,7 +19,7 @@ Given(/^I am a partnership$/) do
   @app.partnership_details_page.add_partner_link.click
 
   # Organisation name page
-  @app.organisation_name_page.submit(partnership_full_name: "Mickey Mouse")
+  @app.organisation_name_page.submit(partnership_full_name: "Fray and Bentos Associates")
 
   # Postcode page
   # We can just click submit because the page pre-populates the postcode lookup
@@ -48,14 +48,14 @@ Given(/^I am a partnership$/) do
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: "tim.stone.ea+1@gmail.com",
-    confirm_email: "tim.stone.ea+1@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -125,8 +125,8 @@ And(/^give "([^"]*)" as the contact$/) do |name|
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    confirm_email: "tim.stone.ea@gmail.com"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page


### PR DESCRIPTION
This is a minor change to remove hard coded email addresses. Tests and rubocop pass so I suggest this can be merged directly.