### PR TITLE
Switch Quke branch to main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "quke",
     git: "https://github.com/DEFRA/quke",
-    branch: "master"
+    branch: "main"
 
 # Rake gives us the ability to create our own commands or 'tasks' for working
 # with quke.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/quke
-  revision: 146e2b63cc4c638ae367ccbab32111ec79cdc984
-  branch: master
+  revision: adb07d14f10b2a3dd3eed3c5ac54a6ad3aa2aaa1
+  branch: main
   specs:
     quke (0.10.0)
       browserstack-local
@@ -18,7 +18,7 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    ast (2.4.0)
+    ast (2.4.1)
     backports (3.17.2)
     browserstack-local (1.3.0)
     builder (3.2.4)
@@ -49,7 +49,6 @@ GEM
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
     gherkin (5.1.0)
-    jaro_winkler (1.5.2)
     launchy (2.5.0)
       addressable (~> 2.7)
     mini_mime (1.0.2)
@@ -58,30 +57,33 @@ GEM
     multi_test (0.1.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.9-x64-mingw32)
-      mini_portile2 (~> 2.4.0)
-    parallel (1.17.0)
-    parser (2.6.3.0)
+    parallel (1.19.2)
+    parser (2.7.1.3)
       ast (~> 2.4.0)
     public_suffix (4.0.5)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
-    rake (12.3.3)
+    rake (13.0.1)
     regexp_parser (1.7.1)
+    rexml (3.2.4)
     rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.68.1)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.85.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.6)
-    ruby-progressbar (1.10.0)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.0.3)
+      parser (>= 2.7.0.1)
+    ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -91,7 +93,7 @@ GEM
       capybara (~> 3.3)
       site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.7.0)
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -101,7 +103,6 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw32
 
 DEPENDENCIES
   quke!
@@ -109,4 +110,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.1.4
+   1.17.3


### PR DESCRIPTION
Because of the work we have been doing to switch our primary branch in our projects to `main` we need to update the reference to the Quke gem.

In my case this meant rebuilding the Gemfile.lock because of an ongoing discrepency with versions of Bundler.