### PR TITLE
Update project to use defra-ruby-style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,73 +1,11 @@
-AllCops:
-  # Cop names are not displayed in offense messages by default. We find it
-  # useful to include this information so we can use it to investigate what the
-  # fix may be.
-  DisplayCopNames: true
-  # Style guide URLs are not displayed in offense messages by default. Again we
-  # find it useful to go straight to the documentation for a rule when
-  # investigating what the fix may be.
-  DisplayStyleGuide: true
+inherit_gem:
+  defra_ruby_style:
+    - default.yml
 
-# We believe it looks cluttered not having the ability to have empty lines after
-# the module, class, and block declarations
-Layout/EmptyLinesAroundBlockBody:
-  Enabled: false
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: false
-Layout/EmptyLinesAroundClassBody:
-  Enabled: false
-
-# We felt as a team that the default size of 15 was too low, and blocked what to
-# us are sound methods which would not add any value if broken up. In this
-# project we've agreed to up this to 30.
-Metrics/AbcSize:
-  Max: 30
-
-# We felt as a team that the default size of 6 was too low, and blocked what to
-# us are sound methods which would not add any value if broken up. In this
-# project we've agreed to up this to 7.
-Metrics/CyclomaticComplexity:
-  Max: 7
-
-# Steps aren't like traditional methods and don't benefit from being broken
-# down. Therefore we exclude them from the block length metric as they often can
-# be long.
+# Our steps are not traditional code blocks and as such rules about there
+# length we don't feel apply. They are a step in a feature and as we want
+# the features to be meaningful, the last thing we want to do is start breaking
+# them up for the sake of this rubocop rule.
 Metrics/BlockLength:
   Exclude:
-    - "**/features/step_definitions/**/*_steps.rb"
-
-# We believe the default of 10 lines for a method length is too restrictive and
-# often quickly hit just because we need to specify the namesspace, class and
-# method before then doing something with it.
-Metrics/MethodLength:
-  Max: 30
-
-# We believe the default 80 characters is too restrictive and that lines can
-# still be readable and maintainable when no more than 120 characters. This also
-# allows us to maximise our screen space.
-Metrics/LineLength:
-  Max: 120
-
-# As long as the team commit to using well named classes it should not be
-# necessary to add top-level class documentation.
-Style/Documentation:
-  Enabled: false
-
-# This rule was added in version 0.49.0. We have nothing against the rule
-# however the code we have it doesn't like is anything that uses strftime().
-# We feel the way we are using that is as expected, so have taken the decision
-# to turn off this cop. https://github.com/bbatsov/rubocop/issues/3438
-Style/FormatStringToken:
-  Enabled: false
-
-# When using Ruby >= 2.3, Rubocop wants to add a comment to the top of *.rb
-# to aid migration to frozen literals in Ruby 3.0. We are not interested in
-# modifying every file at this point, so this cop is disabled for now.
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-# There are no relative performance improvements using '' over "", therefore we
-# believe there is more value in using "" for all strings irrespective of
-# whether string interpolation is used
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
+    - "features/step_definitions/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "quke",
@@ -8,6 +10,6 @@ gem "quke",
 # with quke.
 gem "rake"
 
-# We use rubocop in all our Ruby based projects to try and ensure consistency
-# in the code we write across all our projects.
-gem "rubocop", require: false
+# Gem used by the Defra ruby services team to ensure a consistent style across
+# our code base
+gem "defra_ruby_style"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
+    defra_ruby_style (0.2.2)
+      rubocop (~> 0.82)
     diff-lcs (1.3)
     gherkin (5.1.0)
     launchy (2.5.0)
@@ -105,9 +107,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  defra_ruby_style
   quke!
   rake
-  rubocop
 
 BUNDLED WITH
    1.17.3

--- a/features/hooks/before.rb
+++ b/features/hooks/before.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before do
   # As of 2018-01-15 it appears that tests do not complete in our environments
   # if an element is not visible on the page. This should not be a problem and

--- a/features/page_objects/add_exemption_page.rb
+++ b/features/page_objects/add_exemption_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddExemptionPage < SitePrism::Page
 
   elements(:exemptions, "input[name='add_exemptions[exemption_ids]']")

--- a/features/page_objects/address_page.rb
+++ b/features/page_objects/address_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddressPage < SitePrism::Page
 
   element(:show_list, "input#address_match_selection")

--- a/features/page_objects/admin_nav_bar_section.rb
+++ b/features/page_objects/admin_nav_bar_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AdminNavBarSection < SitePrism::Section
 
   # IMPORTANT! Because of the way the nav-bar works in order to see the options

--- a/features/page_objects/app.rb
+++ b/features/page_objects/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Represents all pages in the application. Was created to avoid needing to
 # create individual instances of each page throughout the steps.
 # https://github.com/natritmeyer/site_prism#epilogue

--- a/features/page_objects/approve_registration_page.rb
+++ b/features/page_objects/approve_registration_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApproveRegistrationPage < SitePrism::Page
 
   element(:asset_found, "#admin_enrollment_exemptions_approve_asset_found")

--- a/features/page_objects/check_exemptions_page.rb
+++ b/features/page_objects/check_exemptions_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CheckExemptionsPage < SitePrism::Page
 
   element(:add_another_exemption, "input[name='Add another exemption']")

--- a/features/page_objects/check_your_answers_page.rb
+++ b/features/page_objects/check_your_answers_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CheckYourAnswersPage < SitePrism::Page
 
   element(:back_link, ".back-link")

--- a/features/page_objects/confirmation_page.rb
+++ b/features/page_objects/confirmation_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConfirmationPage < SitePrism::Page
 
   element(:exemption_number, ".govuk-box-highlight .heading-medium")

--- a/features/page_objects/correspondence_contact_email.rb
+++ b/features/page_objects/correspondence_contact_email.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CorrespondenceContactEmailPage < SitePrism::Page
 
   element(:back_link, ".back-link")

--- a/features/page_objects/correspondence_contact_name_page.rb
+++ b/features/page_objects/correspondence_contact_name_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CorrespondenceContactNamePage < SitePrism::Page
 
   element(:back_link, ".back-link")

--- a/features/page_objects/correspondence_contact_telephone_page.rb
+++ b/features/page_objects/correspondence_contact_telephone_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CorrespondenceContactTelephonePage < SitePrism::Page
 
   element(:back_link, ".back-link")

--- a/features/page_objects/declaration_page.rb
+++ b/features/page_objects/declaration_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeclarationPage < SitePrism::Page
 
   element(:declaration_button, "input[name='commit']")

--- a/features/page_objects/email_someone_else_page.rb
+++ b/features/page_objects/email_someone_else_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EmailSomeoneElsePage < SitePrism::Page
 
   element(:back_link, ".back-link")

--- a/features/page_objects/enrollments_exports_page.rb
+++ b/features/page_objects/enrollments_exports_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EnrollmentExportsPage < SitePrism::Page
 
   element(:export_alert, "div.alert-success[role='alert']")
@@ -19,6 +21,7 @@ class EnrollmentExportsPage < SitePrism::Page
 
   section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     from_day.select(args[:from_day]) if args.key?(:from_day)
     from_month.select(args[:from_month]) if args.key?(:from_month)
@@ -29,5 +32,6 @@ class EnrollmentExportsPage < SitePrism::Page
     to_year.select(args[:to_year]) if args.key?(:to_year)
     request_export.click
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/features/page_objects/front_office_home_page.rb
+++ b/features/page_objects/front_office_home_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FrontOfficeHomePage < SitePrism::Page
 
   set_url("/enrollments/new")

--- a/features/page_objects/grid_reference_page.rb
+++ b/features/page_objects/grid_reference_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GridReferencePage < SitePrism::Page
 
   element(:grid_reference, "input#grid_reference_grid_reference")

--- a/features/page_objects/login_page.rb
+++ b/features/page_objects/login_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LoginPage < SitePrism::Page
 
   set_url(Quke::Quke.config.custom["urls"]["back_office"])

--- a/features/page_objects/organisation_name_page.rb
+++ b/features/page_objects/organisation_name_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OrganisationNamePage < SitePrism::Page
 
   element(:local_authority_name, "input#local_authority_name")
@@ -9,6 +11,7 @@ class OrganisationNamePage < SitePrism::Page
 
   element(:submit_button, "input[name='commit']")
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     local_authority_name.set(args[:local_authority_name]) if args.key?(:local_authority_name)
     ltd_company_name.set(args[:ltd_company_name]) if args.key?(:ltd_company_name)
@@ -19,5 +22,6 @@ class OrganisationNamePage < SitePrism::Page
 
     submit_button.click
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/features/page_objects/partnership_details_page.rb
+++ b/features/page_objects/partnership_details_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PartnershipPage < SitePrism::Page
 
   element(:add_partner_link, "a[href*='/partners/partnership/edit']")

--- a/features/page_objects/postcode_page.rb
+++ b/features/page_objects/postcode_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PostCodePage < SitePrism::Page
 
   element(:local_authority_postcode, "input#local_authority_postcode_postcode")
@@ -9,6 +11,7 @@ class PostCodePage < SitePrism::Page
 
   element(:submit_button, "input[name='commit']")
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     local_authority_postcode.set(args[:local_authority_postcode]) if args.key?(:local_authority_postcode)
     ltd_company_postcode.set(args[:ltd_company_postcode]) if args.key?(:ltd_company_postcode)
@@ -19,5 +22,6 @@ class PostCodePage < SitePrism::Page
 
     submit_button.click
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/features/page_objects/registration_number_page.rb
+++ b/features/page_objects/registration_number_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RegistrationNumberPage < SitePrism::Page
 
   element(:ltd_reg_number, "input#limited_company_number_registration_number")

--- a/features/page_objects/registration_page.rb
+++ b/features/page_objects/registration_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RegistrationPage < SitePrism::Page
 
   element(:edit_address, "#registration-details .btn:first-of-type")

--- a/features/page_objects/reject_registration_page.rb
+++ b/features/page_objects/reject_registration_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RejectRegistrationPage < SitePrism::Page
 
   element(:comment, "#admin_enrollment_exemptions_reject_comment")

--- a/features/page_objects/search_page.rb
+++ b/features/page_objects/search_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SearchPage < SitePrism::Page
 
   element(:alert_success, "div.alert-success[role='alert']", text: "successfully signed in")

--- a/features/page_objects/user_type_page.rb
+++ b/features/page_objects/user_type_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserTypePage < SitePrism::Page
 
   elements(:org_types, "input[name='user_type[org_type]']")

--- a/features/page_objects/withdraw_registration_page.rb
+++ b/features/page_objects/withdraw_registration_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class WithdrawRegistrationPage < SitePrism::Page
 
   element(:comment, "#admin_enrollment_exemptions_withdraw_comment")

--- a/features/step_definitions/back_office/admin_login_steps.rb
+++ b/features/step_definitions/back_office/admin_login_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I have a valid username and password$/) do
   # Back office login page
   @app.login_page.submit(

--- a/features/step_definitions/back_office/correct_address_steps.rb
+++ b/features/step_definitions/back_office/correct_address_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I get to the check your answers page$/) do
   @app.search_page.nav_bar.registrations_menu.click
   @app.search_page.nav_bar.new_option.click

--- a/features/step_definitions/back_office/edit_steps.rb
+++ b/features/step_definitions/back_office/edit_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I "([^"]*)" a submitted registration$/) do |action|
 
   # search page

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I register a flood risk activity exemption for a customer$/) do
 
   @app.search_page.nav_bar.registrations_menu.click

--- a/features/step_definitions/continuous_integration_steps.rb
+++ b/features/step_definitions/continuous_integration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^a cucumber that is (\d+) cm long$/) do |length|
   @cucumber = { color: "green", length: length.to_i }
 end

--- a/features/step_definitions/front_office/check_your_answers_steps.rb
+++ b/features/step_definitions/front_office/check_your_answers_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 And(/^complete the remaining steps as an individual$/) do
 
   # Organisation name page

--- a/features/step_definitions/front_office/individual_steps.rb
+++ b/features/step_definitions/front_office/individual_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am an individual$/) do
   # User type page
   @app.user_type_page.submit(org_type: "individual")

--- a/features/step_definitions/front_office/llp_partnership_steps.rb
+++ b/features/step_definitions/front_office/llp_partnership_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a limited liability partnership$/) do
   # User type page
   @app.user_type_page.submit(org_type: "limited_liability_partnership")

--- a/features/step_definitions/front_office/local_authority_steps.rb
+++ b/features/step_definitions/front_office/local_authority_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a local authority$/) do
   # User type page
   @app.user_type_page.submit(org_type: "local_authority")

--- a/features/step_definitions/front_office/ltd_company_steps.rb
+++ b/features/step_definitions/front_office/ltd_company_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a limited company$/) do
   # User type page
   @app.user_type_page.submit(org_type: "limited_company")

--- a/features/step_definitions/front_office/other_registration_steps.rb
+++ b/features/step_definitions/front_office/other_registration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a charity$/) do
   # User type page
   @app.user_type_page.submit(org_type: "other")

--- a/features/step_definitions/front_office/partnership_steps.rb
+++ b/features/step_definitions/front_office/partnership_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a partnership$/) do
   # User type page
   @app.user_type_page.submit(org_type: "partnership")

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am an external user$/) do
 
   @app = App.new
@@ -71,7 +73,6 @@ Then(/^I will be asked to give the approximate length of dredging planned$/) do
 
 end
 
-# rubocop:disable Lint/HandleExceptions
 Then(/^I will NOT be asked to give the approximate length of dredging planned$/) do
 
   # The previous step is assumed to be 'I select exemption FRA#' which does not
@@ -86,7 +87,6 @@ Then(/^I will NOT be asked to give the approximate length of dredging planned$/)
   end
 
 end
-# rubocop:enable Lint/HandleExceptions
 
 Given(/^I then opt to change FRA(\d+)$/) do |code|
 

--- a/features/step_definitions/helper_steps.rb
+++ b/features/step_definitions/helper_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A set of helper steps, of more use when developing new features and not
 # specific to any given feature or scenario.
 


### PR DESCRIPTION
We now use [defra-ruby-style](https://github.com/DEFRA/defra-ruby-style) across all our projects to ensure consistency in style and conventions across our projects.

This project seems to have escaped the switch! This change updates the project to use defra-ruby-style and resolves any new issues found.