### PR TITLE
Adding Browserstack browser config

### DIFF
--- a/config/browserstack/android.config.yml
+++ b/config/browserstack/android.config.yml
@@ -1,0 +1,136 @@
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'https://fra-dev.aws.defra.cloud'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome, and
+# browserstack, with the default being chrome
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+stop_on_error: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 60
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    SystemUser:
+      username: applicant1@example.com
+      username2: applicant2@example.com
+      password: Abcde12345
+  urls:
+    front_office: "https://fra-dev.aws.defra.cloud"
+    back_office: "https://fra-admin-dev.aws.defra.cloud"
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username:
+  # auth_key:
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key:
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'FRAE'
+    build: 'Flood risk activity exemptions front office tests'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    name: 'Regression tests'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: true
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    device: "Samsung Galaxy S21"
+    os_version: '11.0'
+    real_mobile: true
+    # required to run storage clearing
+    javascriptEnabled: true
+

--- a/config/browserstack/edge_w10.config.yml
+++ b/config/browserstack/edge_w10.config.yml
@@ -1,0 +1,136 @@
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'https://fra-dev.aws.defra.cloud'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome, and
+# browserstack, with the default being chrome
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+stop_on_error: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 60
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    SystemUser:
+      username: applicant1@example.com
+      username2: applicant2@example.com
+      password: Abcde12345
+  urls:
+    front_office: "https://fra-dev.aws.defra.cloud"
+    back_office: "https://fra-admin-dev.aws.defra.cloud"
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username:
+  # auth_key:
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key:
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'FRAE'
+    build: 'Flood risk activity exemptions front office tests'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    name: 'Regression tests'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: true
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: edge
+    os: 'Windows'
+    browser_version: 'latest'
+    os_version: '10'
+    # adding native events to help with clicking label instead of opaque radio button
+    nativeEvents: 'true'

--- a/config/browserstack/firefox_w10.config.yml
+++ b/config/browserstack/firefox_w10.config.yml
@@ -1,0 +1,136 @@
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'https://fra-dev.aws.defra.cloud'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome, and
+# browserstack, with the default being chrome
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+stop_on_error: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 60
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    SystemUser:
+      username: applicant1@example.com
+      username2: applicant2@example.com
+      password: Abcde12345
+  urls:
+    front_office: "https://fra-dev.aws.defra.cloud"
+    back_office: "https://fra-admin-dev.aws.defra.cloud"
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username:
+  # auth_key:
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key:
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'FRAE'
+    build: 'Flood risk activity exemptions front office tests'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    name: 'Regression tests'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: true
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: firefox
+    os: 'Windows'
+    browser_version: 'latest'
+    os_version: '10'
+    # adding native events to help with clicking label instead of opaque radio button
+    nativeEvents: 'true'

--- a/config/browserstack/ie11_w10.config.yml
+++ b/config/browserstack/ie11_w10.config.yml
@@ -1,0 +1,136 @@
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'https://fra-dev.aws.defra.cloud'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome, and
+# browserstack, with the default being chrome
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+stop_on_error: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 60
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    SystemUser:
+      username: applicant1@example.com
+      username2: applicant2@example.com
+      password: Abcde12345
+  urls:
+    front_office: "https://fra-dev.aws.defra.cloud"
+    back_office: "https://fra-admin-dev.aws.defra.cloud"
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username:
+  # auth_key:
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key:
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'FRAE'
+    build: 'Flood risk activity exemptions front office tests'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    name: 'Regression tests'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: true
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: IE
+    os: 'Windows'
+    browser_version: '11.0'
+    os_version: '10'
+    # adding native events to help with clicking label instead of opaque radio button
+    nativeEvents: 'true'

--- a/config/browserstack/iphoneXS.config.yml
+++ b/config/browserstack/iphoneXS.config.yml
@@ -1,0 +1,137 @@
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'https://fra-dev.aws.defra.cloud'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome, and
+# browserstack, with the default being chrome
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+stop_on_error: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 60
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    SystemUser:
+      username: applicant1@example.com
+      username2: applicant2@example.com
+      password: Abcde12345
+  urls:
+    front_office: "https://fra-dev.aws.defra.cloud"
+    back_office: "https://fra-admin-dev.aws.defra.cloud"
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username:
+  # auth_key:
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key:
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'FRAE'
+    build: 'Flood risk activity exemptions front office tests'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    name: 'Regression tests'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: true
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    device: "iPhone XS"
+    os: 'OS X'
+    os_version: '14'
+    real_mobile: true
+    # required to run storage clearing
+    javascriptEnabled: true
+

--- a/config/browserstack/safari_osX.config.yml
+++ b/config/browserstack/safari_osX.config.yml
@@ -1,0 +1,134 @@
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'https://fra-dev.aws.defra.cloud'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome, and
+# browserstack, with the default being chrome
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+stop_on_error: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 60
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    SystemUser:
+      username: applicant1@example.com
+      username2: applicant2@example.com
+      password: Abcde12345
+  urls:
+    front_office: "https://fra-dev.aws.defra.cloud"
+    back_office: "https://fra-admin-dev.aws.defra.cloud"
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username:
+  # auth_key:
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key:
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'FRAE'
+    build: 'Flood risk activity exemptions front office tests'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    name: 'Regression tests'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: true
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: Safari
+    os: 'OS X'
+    browser_version: '14.0'
+    os_version: 'Big Sur'

--- a/features/page_objects/check_your_answers_page.rb
+++ b/features/page_objects/check_your_answers_page.rb
@@ -6,4 +6,8 @@ class CheckYourAnswersPage < SitePrism::Page
 
   element(:submit_button, "input[name='commit']")
 
+  def submit
+    submit_button.click
+  end
+
 end

--- a/features/page_objects/declaration_page.rb
+++ b/features/page_objects/declaration_page.rb
@@ -4,4 +4,7 @@ class DeclarationPage < SitePrism::Page
 
   element(:declaration_button, "input[name='commit']")
 
+  def submit
+    declaration_button.click
+  end
 end

--- a/features/page_objects/enrollments_exports_page.rb
+++ b/features/page_objects/enrollments_exports_page.rb
@@ -21,7 +21,6 @@ class EnrollmentExportsPage < SitePrism::Page
 
   section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     from_day.select(args[:from_day]) if args.key?(:from_day)
     from_month.select(args[:from_month]) if args.key?(:from_month)
@@ -32,6 +31,5 @@ class EnrollmentExportsPage < SitePrism::Page
     to_year.select(args[:to_year]) if args.key?(:to_year)
     request_export.click
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/features/page_objects/enrollments_exports_page.rb
+++ b/features/page_objects/enrollments_exports_page.rb
@@ -21,6 +21,7 @@ class EnrollmentExportsPage < SitePrism::Page
 
   section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     from_day.select(args[:from_day]) if args.key?(:from_day)
     from_month.select(args[:from_month]) if args.key?(:from_month)
@@ -31,5 +32,5 @@ class EnrollmentExportsPage < SitePrism::Page
     to_year.select(args[:to_year]) if args.key?(:to_year)
     request_export.click
   end
-
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/features/page_objects/grid_reference_page.rb
+++ b/features/page_objects/grid_reference_page.rb
@@ -11,7 +11,6 @@ class GridReferencePage < SitePrism::Page
     grid_reference.set(args[:grid_reference]) if args.key?(:grid_reference)
     description.set(args[:description]) if args.key?(:description)
     dredging_length.set(args[:dredging_length]) if args.key?(:dredging_length)
-
     submit_button.click
   end
 

--- a/features/page_objects/organisation_name_page.rb
+++ b/features/page_objects/organisation_name_page.rb
@@ -10,7 +10,7 @@ class OrganisationNamePage < SitePrism::Page
   element(:individual_name, "input#individual_name_name")
 
   element(:submit_button, "input[name='commit']")
-
+  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     local_authority_name.set(args[:local_authority_name]) if args.key?(:local_authority_name)
     ltd_company_name.set(args[:ltd_company_name]) if args.key?(:ltd_company_name)
@@ -21,5 +21,5 @@ class OrganisationNamePage < SitePrism::Page
 
     submit_button.click
   end
-
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/features/page_objects/organisation_name_page.rb
+++ b/features/page_objects/organisation_name_page.rb
@@ -11,7 +11,6 @@ class OrganisationNamePage < SitePrism::Page
 
   element(:submit_button, "input[name='commit']")
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     local_authority_name.set(args[:local_authority_name]) if args.key?(:local_authority_name)
     ltd_company_name.set(args[:ltd_company_name]) if args.key?(:ltd_company_name)
@@ -22,6 +21,5 @@ class OrganisationNamePage < SitePrism::Page
 
     submit_button.click
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/features/page_objects/postcode_page.rb
+++ b/features/page_objects/postcode_page.rb
@@ -11,6 +11,7 @@ class PostCodePage < SitePrism::Page
 
   element(:submit_button, "input[name='commit']")
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     local_authority_postcode.set(args[:local_authority_postcode]) if args.key?(:local_authority_postcode)
     ltd_company_postcode.set(args[:ltd_company_postcode]) if args.key?(:ltd_company_postcode)
@@ -21,5 +22,5 @@ class PostCodePage < SitePrism::Page
 
     submit_button.click
   end
-
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/features/page_objects/postcode_page.rb
+++ b/features/page_objects/postcode_page.rb
@@ -11,7 +11,6 @@ class PostCodePage < SitePrism::Page
 
   element(:submit_button, "input[name='commit']")
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def submit(args = {})
     local_authority_postcode.set(args[:local_authority_postcode]) if args.key?(:local_authority_postcode)
     ltd_company_postcode.set(args[:ltd_company_postcode]) if args.key?(:ltd_company_postcode)
@@ -22,6 +21,5 @@ class PostCodePage < SitePrism::Page
 
     submit_button.click
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/features/step_definitions/back_office/correct_address_steps.rb
+++ b/features/step_definitions/back_office/correct_address_steps.rb
@@ -9,8 +9,10 @@ Given(/^I get to the check your answers page$/) do
   )
 
   expect(page).to have_content("FRA2")
+  expect(page).to have_content("Confirm your exemption")
   @app.check_exemptions_page.submit_button.click
 
+  expect(@app.grid_reference_page).to have_content("activity")
   @app.grid_reference_page.submit(
     grid_reference: "ST 58132 72695",
     description: "Location of activity"
@@ -26,6 +28,7 @@ Given(/^I get to the check your answers page$/) do
   @app.postcode_page.submit(individual_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -42,12 +45,14 @@ Given(/^I get to the check your answers page$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
@@ -82,9 +87,12 @@ When(/^I enter the address manually and complete the registration$/) do
 
   @app.correspondence_contact_name_page.submit_button.click
   @app.correspondence_contact_telephone_page.submit_button.click
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit_button.click
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit_button.click
-  @app.check_your_answers_page.submit_button.click
+  expect(@app.check_your_answers_page).to have_content("Check your answers")
+  @app.check_your_answers_page.submit
 
   @app.declaration_page.declaration_button.click
 

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -10,8 +10,10 @@ When(/^I register a flood risk activity exemption for a customer$/) do
   )
 
   expect(page).to have_content("FRA2")
+  expect(page).to have_content("Confirm your exemption")
   @app.check_exemptions_page.submit_button.click
 
+  expect(@app.grid_reference_page).to have_content("activity")
   @app.grid_reference_page.submit(
     grid_reference: "ST 58132 72695",
     description: "Location of activity"
@@ -27,6 +29,7 @@ When(/^I register a flood risk activity exemption for a customer$/) do
   @app.postcode_page.submit(individual_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -43,19 +46,22 @@ When(/^I register a flood risk activity exemption for a customer$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page
-  @app.check_your_answers_page.submit_button.click
+  expect(@app.check_your_answers_page).to have_content("Check your answers")
+  @app.check_your_answers_page.submit
 
   @app.declaration_page.declaration_button.click
 

--- a/features/step_definitions/front_office/check_your_answers_steps.rb
+++ b/features/step_definitions/front_office/check_your_answers_steps.rb
@@ -25,12 +25,14 @@ And(/^complete the remaining steps as an individual$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit_button.click
 
 end

--- a/features/step_definitions/front_office/individual_steps.rb
+++ b/features/step_definitions/front_office/individual_steps.rb
@@ -11,6 +11,7 @@ Given(/^I am an individual$/) do
   @app.postcode_page.submit(individual_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -27,17 +28,20 @@ Given(/^I am an individual$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page
-  @app.check_your_answers_page.submit_button.click
+  expect(@app.check_your_answers_page).to have_content("Check your answers")
+  @app.check_your_answers_page.submit
 end

--- a/features/step_definitions/front_office/llp_partnership_steps.rb
+++ b/features/step_definitions/front_office/llp_partnership_steps.rb
@@ -14,6 +14,7 @@ Given(/^I am a limited liability partnership$/) do
   @app.postcode_page.submit(llp_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -30,17 +31,20 @@ Given(/^I am a limited liability partnership$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page
-  @app.check_your_answers_page.submit_button.click
+  expect(@app.check_your_answers_page).to have_content("Check your answers")
+  @app.check_your_answers_page.submit
 end

--- a/features/step_definitions/front_office/local_authority_steps.rb
+++ b/features/step_definitions/front_office/local_authority_steps.rb
@@ -11,6 +11,7 @@ Given(/^I am a local authority$/) do
   @app.postcode_page.submit(local_authority_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -27,17 +28,19 @@ Given(/^I am a local authority$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
-
-  @app.check_your_answers_page.submit_button.click
+  expect(@app.check_your_answers_page).to have_content("Check your answers")
+  @app.check_your_answers_page.submit
 
 end

--- a/features/step_definitions/front_office/ltd_company_steps.rb
+++ b/features/step_definitions/front_office/ltd_company_steps.rb
@@ -14,6 +14,7 @@ Given(/^I am a limited company$/) do
   @app.postcode_page.submit(ltd_company_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -30,17 +31,20 @@ Given(/^I am a limited company$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page
-  @app.check_your_answers_page.submit_button.click
+  expect(@app.check_your_answers_page).to have_content("Check your answers")
+  @app.check_your_answers_page.submit
 end

--- a/features/step_definitions/front_office/other_registration_steps.rb
+++ b/features/step_definitions/front_office/other_registration_steps.rb
@@ -11,6 +11,7 @@ Given(/^I am a charity$/) do
   @app.postcode_page.submit(other_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -27,17 +28,20 @@ Given(/^I am a charity$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page
-  @app.check_your_answers_page.submit_button.click
+  expect(@app.check_your_answers_page).to have_content("Check your answers")
+  @app.check_your_answers_page.submit
 end

--- a/features/step_definitions/front_office/partnership_steps.rb
+++ b/features/step_definitions/front_office/partnership_steps.rb
@@ -11,6 +11,7 @@ Given(/^I am a partnership$/) do
   @app.postcode_page.submit(partnership_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -26,15 +27,18 @@ Given(/^I am a partnership$/) do
   # Postcode page
   # We can just click submit because the page pre-populates the postcode lookup
   # field with the previously entered postcode
+  expect(page).to have_content("BS1 5AH")
   @app.postcode_page.submit_button.click
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Partnership details page - again!
   # The continue button should now be visible
+  expect(@app.partnership_details_page).to have_content("Business partners you’ve added to this registration")
   @app.partnership_details_page.submit_button.click
 
   # Correspondence contact name page
@@ -49,19 +53,22 @@ Given(/^I am a partnership$/) do
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username2"]
   )
 
   # Check your answers page
-  @app.check_your_answers_page.submit_button.click
+  expect(@app.check_your_answers_page).to have_content("Check your answers")
+  @app.check_your_answers_page.submit
 end
 
 And(/^add "([^"]*)" as the first partner$/) do |name|
@@ -70,9 +77,11 @@ And(/^add "([^"]*)" as the first partner$/) do |name|
   @app.organisation_name_page.submit(partnership_full_name: name)
 
   # Postcode page
+  expect(page).to have_content("postcode")
   @app.postcode_page.submit(partnership_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
+  expect(page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -90,9 +99,11 @@ And(/^add "([^"]*)" as a partner$/) do |name|
   # Postcode page
   # We can just click submit because the page pre-populates the postcode lookup
   # field with the previously entered postcode
+  expect(@app.postcode_page).to have_content("the address")
   @app.postcode_page.submit_button.click
 
   # Address page - select address from post code lookup list
+  expect(@app.address_page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -110,15 +121,18 @@ And(/^add "([^"]*)" as the last partner$/) do |name|
   # Postcode page
   # We can just click submit because the page pre-populates the postcode lookup
   # field with the previously entered postcode
+  expect(@app.postcode_page).to have_content("What’s the address")
   @app.postcode_page.submit_button.click
 
   # Address page - select address from post code lookup list
+  expect(@app.address_page).to have_content("I can’t find the address in the list")
   @app.address_page.submit(
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Partnership details page
   # The continue button should now be visible
+  expect(@app.partnership_details_page).to have_content("Business partners you’ve added to this registration")
   @app.partnership_details_page.submit_button.click
 
 end
@@ -138,9 +152,8 @@ But(/^then remove "([^"]*)" from the partners list$/) do |name|
 end
 
 Then(/^I will just see the remaining 2 partners$/) do
-
+  sleep(1)
   expect(@app.partnership_details_page.remove_links.length).to eq(2)
   expect(page).to have_content("Steve Rogers")
   expect(page).to have_content("Tony Stark")
-
 end

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -22,12 +22,14 @@ Given(/^I am an unknown user$/) do
 end
 
 Given(/^I register exemption FRA(\d+)$/) do |code|
-
+  expect(@app.add_exemption_page).to have_content("Select the exemption you want to register")
   @app.add_exemption_page.submit(exemption: "FRA#{code}")
 
-  expect(page).to have_content("FRA#{code}")
+  expect(@app.check_exemptions_page).to have_content("FRA#{code}")
+  expect(@app.check_exemptions_page).to have_content("Confirm your exemption")
   @app.check_exemptions_page.submit_button.click
 
+  expect(@app.grid_reference_page).to have_content("activity")
   @app.grid_reference_page.submit(
     grid_reference: "ST 58132 72695",
     description: "Location of activity"
@@ -50,9 +52,12 @@ When(/^I select exemption FRA(\d+) as a "([^"]*)"$/) do |code, org_type|
 
   # Check exemptions page
   expect(page).to have_content("FRA#{code}")
+  expect(page).to have_content("Confirm your exemption")
+
   @app.check_exemptions_page.submit_button.click
 
   # Grid reference page
+  expect(@app.grid_reference_page).to have_content("National Grid reference")
   @app.grid_reference_page.submit(
     grid_reference: "ST 58132 72695",
     description: "Location of activity"
@@ -67,6 +72,7 @@ Then(/^I will be asked to give the approximate length of dredging planned$/) do
 
   # The previous step is assumed to be 'I select exemption FRA#' which does not
   # click the submit button, hence its the first action we have to take here.
+  expect(page).to have_content("Confirm your exemption")
   @app.check_exemptions_page.submit_button.click
 
   expect(@app.grid_reference_page.dredging_length).not_to be_nil
@@ -77,6 +83,7 @@ Then(/^I will NOT be asked to give the approximate length of dredging planned$/)
 
   # The previous step is assumed to be 'I select exemption FRA#' which does not
   # click the submit button, hence its the first action we have to take here.
+  expect(page).to have_content("Confirm your exemption")
   @app.check_exemptions_page.submit_button.click
 
   begin
@@ -103,11 +110,12 @@ Then(/^I will be taken back to the add exemptions page$/) do
 end
 
 When(/^I confirm my registration$/) do
-  @app.declaration_page.declaration_button.click
+  expect(page).to have_content("Declaration")
+  @app.declaration_page.submit
 end
 
 Then(/^I will see confirmation my registration has been submitted$/) do
-  expect(page).to have_content "Registration submitted"
+  expect(@app.confirmation_page).to have_content "Registration submitted"
 end
 
 And(/^give "([^"]*)" as the contact$/) do |name|
@@ -124,12 +132,14 @@ And(/^give "([^"]*)" as the contact$/) do |name|
   )
 
   # Correspondence contact email address page
+  expect(@app.correspondence_contact_email_page).to have_content("What’s the email address")
   @app.correspondence_contact_email_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
     confirm_email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   )
 
   # Email someone else page
+  expect(@app.email_someone_else_page).to have_content("confirmation email")
   @app.email_someone_else_page.submit_button.click
 
 end


### PR DESCRIPTION
Adds config files to run regression tests on supported browsers and devices, also adds in some page content checks to slow down the automation enough for some browsers not to click the submit button twice on the same page.