### PR TITLE
Add Linux platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.3)
     ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
     http-accept (1.7.0)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
@@ -115,6 +116,8 @@ GEM
     multi_test (1.1.0)
     netrc (0.11.0)
     nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     os_map_ref (0.5.0)
     parallel (2.1.0)
@@ -200,7 +203,8 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   defra_ruby_style


### PR DESCRIPTION
Jenkins runs the acceptance tests on Linux, but the current lockfile only includes the macOS native variants for ffi and nokogiri.

This adds the x86_64-linux platform back to Gemfile.lock so Bundler has Linux-compatible native specs available during install.